### PR TITLE
Macro support (#3) and improved nunjucks processing 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Checkout example and test fixtures with linux line ending
+# to guarantee test successes
+example/** text eol=lf
+test/fixtures/** text eol=lf

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -5,31 +5,8 @@ var assign = require('lodash/object/assign'),
 
 function Generator(druck) {
 
-  /**
-   * Get all includes for the given page.
-   *
-   * @param {Object} page
-   *
-   * @return {Array<String>} include paths
-   */
-  function getIncludePaths(page) {
-    var globalIncludes = druck.config.includes || [];
-
-    return globalIncludes.concat(getPageIncludePaths(page));
-  }
-
-  /**
-   * Get includes template.
-   *
-   * @param {Object} page
-   *
-   * @return {String} includes template
-   */
-  function getIncludes(page) {
-    return getIncludePaths(page).map(function(path) {
-      return '{% include "' + withExtension(path, 'html') + '" %}\n';
-    }).join('');
-  }
+  var CONTENT_START_TAG = '<~~page-content>';
+  var CONTENT_END_TAG   = '</~~page-content>';
 
   function render(page, locals, layout) {
 
@@ -45,36 +22,47 @@ function Generator(druck) {
       }
     });
 
-    var includesTemplate = getIncludes(page);
-
     var rendered = page.body;
+    var contentNeedsProcessing = druck.isMarkdown(page);
 
-    if (druck.isMarkdown(page)) {
-
-      // (1.0) process nunjucks templates and variables in
-      // markdown file, taking macros into account
-      rendered = nunjucks.renderString(includesTemplate + rendered, locals);
-
-      // (1.1) process markdown
-      rendered = marked(rendered);
-
-      // 1.2 wrap with item_body block to allow inclusion
-      // into parent template
-      rendered =
-        '{% block item_body %}\n' +
-        rendered + '\n' +
-        '{% endblock %}\n';
+    // (1.0) mark content-area if content processing is requested
+    if (contentNeedsProcessing) {
+      rendered = CONTENT_START_TAG + rendered + CONTENT_END_TAG;
     }
 
+    // (1.1) wrap with item_body block to allow inclusion
+    // into parent template
+    rendered =
+      '{% block item_body %}\n' +
+      rendered + '\n' +
+      '{% endblock %}\n';
+
+    // (1.2) extend layout if necessary
     if (layout && page.layout) {
-      // (2.0) handle page as if layout is needed
       rendered =
         '{% extends "' + withExtension(page.layout, 'html') + '" %}\n' +
-        includesTemplate +
         rendered;
     }
 
+    // (1.3) render nunjucks template
     rendered = nunjucks.renderString(rendered, locals);
+
+    // (1.4) handle content post-processing
+    if (contentNeedsProcessing) {
+
+      // (1.4.1) extract page content
+      var renderedParts = rendered.split(new RegExp('(' + escapeRegExp(CONTENT_START_TAG) + '|' + escapeRegExp(CONTENT_END_TAG) + ')'));
+      if (renderedParts.length !== 5) {
+        throw new Error('The tags [' + CONTENT_START_TAG + ', ' + CONTENT_END_TAG + '] may not be used in template or page files.');
+      }
+      var content = renderedParts[2];
+
+      // (1.4.2) render page content
+      content = marked(content);
+
+      // (1.4.3) plug rendered content back in
+      rendered = renderedParts[0] + content + renderedParts[4];
+    }
 
     return rendered;
   }
@@ -129,25 +117,15 @@ module.exports = Generator;
 /////// utilities //////////////////////////////////////////
 
 /**
- * Extract includes from a page.
+ * Escape a string for use as regex. Should not be used on escaped strings.
  *
- * @param {Object} page
+ * @param {String} string to escape
  *
- * @return {Array<String>} includes to use
+ * @return {String} escaped string
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
  */
-function getPageIncludePaths(page) {
-
-  var include = page.include;
-
-  if (!include) {
-    return [];
-  }
-
-  if (isString(include)) {
-    include = [ include ];
-  }
-
-  return include;
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**

--- a/test/fixtures/includes/pages/global-includes.md
+++ b/test/fixtures/includes/pages/global-includes.md
@@ -1,5 +1,0 @@
----
-layout: base.html
----
-
-{{ img(src='foo.gif', caption='FOO') }}

--- a/test/fixtures/includes/pages/page-include.md
+++ b/test/fixtures/includes/pages/page-include.md
@@ -1,6 +1,0 @@
----
-layout: base
-include: macros/empty
----
-
-{{ img(src='foo.gif', caption='FOO') }}

--- a/test/fixtures/includes/templates/base.html
+++ b/test/fixtures/includes/templates/base.html
@@ -1,5 +1,0 @@
-<base>
-  <!-- macro should be available in body -->
-  {% block item_body %}
-  {% endblock %}
-</base>

--- a/test/fixtures/includes/templates/macros/default.html
+++ b/test/fixtures/includes/templates/macros/default.html
@@ -1,7 +1,0 @@
-<!-- macro definition -->
-{% macro img(src='', caption='', cls='') %}
-<img src="{{ src }}" class="{{ className }}" />
-{% if caption %}
-<span class="caption">{{ caption }}</span>
-{% endif %}
-{% endmacro %}

--- a/test/fixtures/includes/templates/macros/empty.html
+++ b/test/fixtures/includes/templates/macros/empty.html
@@ -1,4 +1,0 @@
-<!-- macro definition -->
-{% macro img(src='', caption='', cls='') %}
-<h1>FOO BAR</h1>
-{% endmacro %}

--- a/test/fixtures/macro-support/kartoffeldruck.js
+++ b/test/fixtures/macro-support/kartoffeldruck.js
@@ -1,11 +1,5 @@
 module.exports = function(druck) {
 
-  druck.configure({
-    includes: [
-      'macros/default.html'
-    ]
-  });
-
   druck.generate({
     source: '*.md',
     dest: ':name.html'

--- a/test/fixtures/macro-support/pages/layout-macro.md
+++ b/test/fixtures/macro-support/pages/layout-macro.md
@@ -1,0 +1,5 @@
+---
+layout: macro-base
+---
+
+{{ img('foo.gif', caption='FOO') }}

--- a/test/fixtures/macro-support/pages/page-macro.md
+++ b/test/fixtures/macro-support/pages/page-macro.md
@@ -1,0 +1,10 @@
+---
+---
+
+<!-- macro definition -->
+{% macro hello(name) %}
+<h1>Hello {{ name }}!</h1>
+{% endmacro %}
+
+<!-- content -->
+{{ hello('World') }}

--- a/test/fixtures/macro-support/templates/macro-base.html
+++ b/test/fixtures/macro-support/templates/macro-base.html
@@ -1,0 +1,13 @@
+<!-- macro definition -->
+{% macro img(src, caption='', cls='') %}
+<img src="{{ src }}" class="{{ className }}" />
+{% if caption %}
+<span class="caption">{{ caption }}</span>
+{% endif %}
+{% endmacro %}
+
+<base>
+  <!-- macro should be available in body -->
+  {% block item_body %}
+  {% endblock %}
+</base>

--- a/test/spec/generator.js
+++ b/test/spec/generator.js
@@ -216,12 +216,12 @@ describe('generator', function() {
   });
 
 
-  describe('includes', function() {
+  describe('macro support', function() {
 
     before(function() {
-      druck = Kartoffeldruck.run({ cwd: 'test/fixtures/includes' });
+      druck = Kartoffeldruck.run({ cwd: 'test/fixtures/macro-support' });
 
-      expectGenerated = createValidator('test/fixtures/includes');
+      expectGenerated = createValidator('test/fixtures/macro-support');
     });
 
     after(function() {
@@ -229,9 +229,9 @@ describe('generator', function() {
     });
 
 
-    it('should process global includes in markdown', function() {
+    it('should enable the use of macros defined in templates within pages', function() {
 
-      expectGenerated('global-includes.html', [
+      expectGenerated('layout-macro.html', [
         '<img src="foo.gif" class="" />',
         '<span class="caption">FOO</span>'
       ]);
@@ -239,10 +239,10 @@ describe('generator', function() {
     });
 
 
-    it('should process page include in markdown', function() {
+    it('should allow macro definitions from within a page', function() {
 
-      expectGenerated('page-include.html', [
-        '<h1>FOO BAR</h1>'
+      expectGenerated('page-macro.html', [
+        '<h1>Hello World!</h1>'
       ]);
 
     });


### PR DESCRIPTION
This pull request changes the template/content processing to enable macro support (#3). The following workflow is implemented:
1. combine page with or without layout (property given or not)
2. mark the content
3. template processing
4. extract content, process it with markdown, and add it back without marker

Additionally, it enforces LF checkout for the folders `example/**` as well as `test/fixtures/**` in order to guarantee test success on Windows machines.

Inclusion support implemented in an earlier commit from the branch this is based on was dropped.
