### PR TITLE
Generalize content processing with markdown as default (implements #4)

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,9 +1,10 @@
 var assign = require('lodash/object/assign'),
     mapValues = require('lodash/object/mapValues'),
     isString = require('lodash/lang/isString'),
-    marked = require('marked');
+    isEmpty = require('lodash/lang/isEmpty'),
+    forEach = require('lodash/collection/forEach');
 
-var MARKDOWN_MARKER = '<~~markdown~marker~~>';
+var CONTENT_MARKER = '<~~content~marker~~>';
 
 
 function Generator(druck) {
@@ -12,19 +13,25 @@ function Generator(druck) {
     return druck.getNunjucks().renderString(template, locals);
   }
 
-  function markMarkdown(template) {
-    return MARKDOWN_MARKER + template + MARKDOWN_MARKER;
+  function markContent(template) {
+    return CONTENT_MARKER + template + CONTENT_MARKER;
   }
 
-  function renderMarkdown(template) {
+  function renderContent(template, page, contentProcessors) {
 
-    var split = template.split(MARKDOWN_MARKER);
+    var split = template.split(CONTENT_MARKER);
 
     if (split.length !== 3) {
-      throw new Error('must not use markdown marker (' + MARKDOWN_MARKER + ') in template or page');
+      throw new Error('must not use content marker (' + CONTENT_MARKER + ') in template or page');
     }
 
-    return split[0] + marked(split[1]) + split[2];
+    var content = split[1];
+
+    forEach(contentProcessors, function(contentProcessor) {
+      content = contentProcessor(content, page);
+    });
+
+    return split[0] + content + split[2];
   }
 
   function render(page, locals, layout) {
@@ -39,12 +46,11 @@ function Generator(druck) {
     });
 
     var rendered = page.body;
-
-    var isMarkdown = druck.isMarkdown(page);
+    var contentProcessors = druck.getContentProcessors(page);
 
     // (1.0) mark content-area if content processing is requested
-    if (isMarkdown) {
-      rendered = markMarkdown(rendered);
+    if (!isEmpty(contentProcessors)) {
+      rendered = markContent(rendered);
     }
 
     // (1.1) wrap with item_body block to allow inclusion
@@ -64,9 +70,9 @@ function Generator(druck) {
     // (1.3) render nunjucks template
     rendered = renderNunjucks(rendered, locals);
 
-    // (1.4) perform optional markdown post-processing
-    if (isMarkdown) {
-      rendered = renderMarkdown(rendered);
+    // (1.4) perform optional content post-processing
+    if (!isEmpty(contentProcessors)) {
+      rendered = renderContent(rendered, page, contentProcessors);
     }
 
     return rendered;

--- a/lib/kartoffeldruck.js
+++ b/lib/kartoffeldruck.js
@@ -2,12 +2,16 @@ var isArray = require('lodash/lang/isArray'),
     isString = require('lodash/lang/isString'),
     assign = require('lodash/object/assign'),
     merge = require('lodash/object/merge'),
+    pick = require('lodash/object/pick'),
     forEach = require('lodash/collection/forEach'),
     del = require('del'),
     mkdirp = require('mkdirp'),
     EventEmitter = require('events').EventEmitter;
 
 var Nunjucks = require('nunjucks');
+
+var marked = require('marked'),
+    minimatch = require('minimatch');
 
 var colors = require('colors/safe');
 
@@ -58,6 +62,29 @@ Kartoffeldruck.prototype.getNunjucks = function() {
   }
 
   return nunjucks;
+};
+
+Kartoffeldruck.prototype.getContentProcessors = function(page) {
+  var config = this.config;
+
+  function markdownProcessor(content, page) {
+    return marked(content);
+  }
+
+  var contentProcessors = config.contentProcessors;
+
+  // if contentProcessing is not explicitly turned off
+  // we enable markdown processing behviour for *.md files
+  if (contentProcessors === undefined) {
+    contentProcessors = { '*.md': markdownProcessor };
+  }
+
+  // only return those processors suitable for the given page
+  contentProcessors = pick(contentProcessors, function(processor, glob) {
+    return minimatch(page.id, glob, { nocase: true, matchBase: true });
+  });
+
+  return contentProcessors;
 };
 
 Kartoffeldruck.prototype.init =
@@ -227,10 +254,6 @@ Kartoffeldruck.prototype.loadFile = function(id) {
   body = fm.body;
 
   return new Page(id, id.replace(/\.[^.]+$/, ''), attributes, body);
-};
-
-Kartoffeldruck.prototype.isMarkdown = function(page) {
-  return page.id.match(/\.md$/);
 };
 
 Kartoffeldruck.prototype.ensureDirExists = function(filePath) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "lodash": "^3.1.0",
     "marked": "^0.3.3",
     "mkdirp": "^0.5.0",
-    "nunjucks": "^1.2.0"
+    "nunjucks": "^1.2.0",
+    "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/fixtures/content-processors/kartoffeldruck.js
+++ b/test/fixtures/content-processors/kartoffeldruck.js
@@ -1,0 +1,8 @@
+module.exports = function(druck) {
+
+  druck.generate({
+    source: '*',
+    dest: ':name.html'
+  });
+
+};

--- a/test/fixtures/content-processors/pages/as-is.txt
+++ b/test/fixtures/content-processors/pages/as-is.txt
@@ -1,0 +1,4 @@
+---
+---
+
+## This file is not processed.

--- a/test/fixtures/content-processors/pages/markdown.md
+++ b/test/fixtures/content-processors/pages/markdown.md
@@ -1,0 +1,4 @@
+---
+---
+
+## This file is markdown-processed by default.

--- a/test/fixtures/content-processors/pages/to-lowercase.uppercase
+++ b/test/fixtures/content-processors/pages/to-lowercase.uppercase
@@ -1,0 +1,4 @@
+---
+---
+
+ALL TEXT HERE IS UPPERCASE.

--- a/test/fixtures/non-markdown/kartoffeldruck.js
+++ b/test/fixtures/non-markdown/kartoffeldruck.js
@@ -1,0 +1,24 @@
+var forEach = require('lodash/collection/forEach');
+
+module.exports = function(druck) {
+
+  // grep for files
+
+  var posts = druck.files('posts/*');
+
+  // each post on its own page
+
+  druck.generate({
+    source: posts,
+    dest: ':name/index.html'
+  });
+
+  // published posts list
+
+  druck.generate({
+    source: 'index.html',
+    dest: ':page/index.html',
+    locals: { items: posts },
+    paginate: 5
+  });
+};

--- a/test/fixtures/non-markdown/pages/index.html
+++ b/test/fixtures/non-markdown/pages/index.html
@@ -1,0 +1,11 @@
+---
+
+title: My blog
+layout: post_list
+
+---
+
+
+{% block header %}
+  <h2>Welcome to my blog</h2>
+{% endblock %}

--- a/test/fixtures/non-markdown/pages/posts/01-first.txt
+++ b/test/fixtures/non-markdown/pages/posts/01-first.txt
@@ -1,0 +1,9 @@
+---
+
+title: first
+
+layout: post
+
+---
+
+## A markdown headline

--- a/test/fixtures/non-markdown/pages/posts/02-second.txt
+++ b/test/fixtures/non-markdown/pages/posts/02-second.txt
@@ -1,0 +1,12 @@
+---
+
+title: second
+tags: [ a ]
+draft: true
+layout: post
+
+---
+
+Other post.
+
+*YEA*!

--- a/test/fixtures/non-markdown/templates/base.html
+++ b/test/fixtures/non-markdown/templates/base.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+  <title>{{ title }}</title>
+  {% block head %}{% endblock %}
+</head>
+<body>
+  {% block body %}{% endblock %}
+</body>
+</html>

--- a/test/fixtures/non-markdown/templates/blog.html
+++ b/test/fixtures/non-markdown/templates/blog.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block body %}
+  <div class="content">
+    {% block header %}{% endblock %}
+    {% block content %}{% endblock %}
+  </div>
+  <div class="sidebar">
+    {% block sidebar %}{% endblock %}
+  </div>
+{% endblock %}

--- a/test/fixtures/non-markdown/templates/post.html
+++ b/test/fixtures/non-markdown/templates/post.html
@@ -1,0 +1,10 @@
+{% extends "blog.html" %}
+
+{% block content %}
+<div class="post">
+  <h1>{{ title }}</h1>
+
+  {% block item_body %}
+  {% endblock %}
+</div>
+{% endblock %}

--- a/test/fixtures/non-markdown/templates/post_list.html
+++ b/test/fixtures/non-markdown/templates/post_list.html
@@ -1,0 +1,20 @@
+{% extends "blog.html" %}
+
+{% block content %}
+  {% for item in items %}
+    <div class="item">
+      <h1><a href="{{ relative(item.name) }}">{{ item.title }}</a></h1>
+
+      {{ render(item) }}
+    </div>
+  {% endfor %}
+
+  {% if page.previousRef != null %}
+    <a href="{{ relative(page.previousRef) }}">previous</a>
+  {% endif %}
+
+  {% if page.nextRef != null %}
+    <a href="{{ relative(page.nextRef) }}">next</a>
+  {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Allow multiple content processors using marked as default processor for *.md files (compat behaviour). Implements #4.

Processors can be defined in the configuration as follows:

```
{
  contentProcessors: {
    '*.md': function(content, page) { return marked(content); },
    '*': function(content, page) { return emoji(content); },
  }
}
```

Object keys are globs matched against the page's id (i.e., including relative path) using minimatch with the options `{ nocase: true, matchBase: true }`. Processor order is preserved, such that multiple matching processors are applied in the order defined.

Also adds tests for non-markdown file processing and aggregation based off the example structure.

Finally, the method `Kartoffeldruck.isMarkdown` is removed from the +public+ API.
