### PR TITLE
Implement generation event (fixes #8)

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -80,6 +80,7 @@ function Generator(druck) {
 
     var rendered = render(source, locals, true);
     druck.writeFile(dest, rendered);
+    return rendered;
   }
 
   /**

--- a/lib/kartoffeldruck.js
+++ b/lib/kartoffeldruck.js
@@ -176,11 +176,16 @@ Kartoffeldruck.prototype.generate = function(options) {
   // basic generate
 
   var locals = assign({}, this.config.locals, options.locals);
-
-  this.generator.generate(assign({ }, options, {
+  var dest = this.expandUri(options.dest, source, locals);
+  var pageOptions = assign({ }, options, {
     source: source,
-    dest: this.expandUri(options.dest, source, locals),
+    dest: dest,
     locals: locals
+  });
+
+  var rendered = this.generator.generate(pageOptions);
+  this.emit('generated', assign({}, pageOptions, {
+    rendered: rendered
   }));
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "nunjucks": "^2.3.0"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^3.5.0",
     "mocha": "^2.1.0",
     "nunjucks-date": "^1.1.2"
   }

--- a/test/mock/generator.js
+++ b/test/mock/generator.js
@@ -4,6 +4,7 @@ function Generator() {
 
   this.generate = function(options) {
     this._generated.push(options);
+    return 'rendered';
   };
 }
 

--- a/test/spec/kartoffeldruck.js
+++ b/test/spec/kartoffeldruck.js
@@ -225,6 +225,73 @@ describe('kartoffeldruck.js descriptor', function() {
 
     });
 
+
+    describe('events', function() {
+
+      it('should trigger an event on paginated page generation', function() {
+
+        // given
+        var posts = druck.files('posts/*');
+
+        var results = [];
+        druck.on('generated', function(event) {
+          results.push(event);
+        });
+
+        // when
+        druck.generate({
+          source: 'index.html',
+          dest: ':page/index.html',
+          locals: { items: posts },
+          paginate: 1,
+          myCustomProp: 'HOME'
+        });
+
+        // then
+        expect(results.length).to.eql(2);
+
+        expect(results[0].dest).to.eql('index.html');
+        expect(results[1].dest).to.eql('2/index.html');
+
+        results.every(function(result, index) {
+          expect(result.rendered).to.eql('rendered');
+          expect(result.myCustomProp).to.eql('HOME');
+          expect(result.locals.items).to.eql([posts[index]]);
+        });
+      });
+
+      it('should trigger an event on wildcard page generation', function() {
+
+        // given
+        var results = [];
+        druck.on('generated', function(event) {
+          results.push(event);
+        });
+
+        // when
+        druck.generate({
+          source: 'posts/*',
+          dest: ':name/index.html',
+          myCustomProp: 'HOME'
+        });
+
+        // then
+        expect(results.length).to.eql(2);
+
+        expect(results[0].source.id).to.eql('posts/01-first.md');
+        expect(results[0].dest).to.eql('posts/01-first/index.html');
+        expect(results[1].source.id).to.eql('posts/02-second.md');
+        expect(results[1].dest).to.eql('posts/02-second/index.html');
+
+        results.every(function(result) {
+          expect(result).to.contain.all.keys('dest', 'source', 'rendered', 'locals', 'myCustomProp');
+          expect(result.rendered).to.eql('rendered');
+          expect(result.myCustomProp).to.eql('HOME');
+        });
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Implements a generation callback `druck.on('generated', function(event) { ... })` with `event` providing access to `{dest, source (not the original source!), locals, rendered, ...custom props}`.

The interface from `Generator.generate` was extended in that it returns the generated output. Additionally, this commit upgrades chai to the latest stable as the functionality `expect(result).to.contain.all.keys('dest', 'source', 'rendered', 'locals', 'myCustomProp');` was desired.

General observations:
It is to some extend unpredictable what outcome will be available in the callback's argument (but also within the generator#generate) without having knowledge of the internals and the templates. This is for the following reasons:

The rather arguable design decision to implement pagination via `locals.items`. This value could easily be overridden page/template internally via the front-matter and/or the latter has no effect.

Also, the `Kartoffeldruck.prototype.generate` method as it stands now provides quite some unexpected behavior:
1. it discards `pagination: 1` property (and probably some others, but which?)
2. it overrides initial source, which forces the author to specify it twice in the hash provided as options if required within the event callback
