### PR TITLE
`last/firstRef` while pagination

### DIFF
--- a/lib/kartoffeldruck.js
+++ b/lib/kartoffeldruck.js
@@ -150,7 +150,9 @@ Kartoffeldruck.prototype.generate = function(options) {
             idx: idx,
             totalPages: totalPages,
             previousRef: (idx > 0 ? self.expandUri(options.dest, source, locals, idx - 1).replace(/\/?index\.html$/, '') : null),
-            nextRef: (idx + 1 < totalPages ? self.expandUri(options.dest, source, locals, idx + 1).replace(/\/?index\.html$/, '') : null)
+            nextRef: (idx + 1 < totalPages ? self.expandUri(options.dest, source, locals, idx + 1).replace(/\/?index\.html$/, '') : null),
+            firstRef: self.expandUri(options.dest, source, locals, 0).replace(/\/?index\.html$/, ''),
+            lastRef: self.expandUri(options.dest, source, locals, totalPages - 1).replace(/\/?index\.html$/, '')
           }
         })
       });

--- a/test/spec/kartoffeldruck.js
+++ b/test/spec/kartoffeldruck.js
@@ -142,6 +142,8 @@ describe('kartoffeldruck.js descriptor', function() {
                 idx: 0,
                 nextRef: '2',
                 previousRef: null,
+                firstRef: '',
+                lastRef: '2',
                 totalPages: 2
               }
             },
@@ -172,6 +174,8 @@ describe('kartoffeldruck.js descriptor', function() {
                 idx: 1,
                 nextRef: null,
                 previousRef: '',
+                firstRef: '',
+                lastRef: '2',
                 totalPages: 2
               }
             },


### PR DESCRIPTION
Gives access to `last/firstRef` while pagination. This allows to build `go to first/last page` links, but also to properly link resources like feeds, in case these are generated in the base directory (which is the `firstRef`).

Code not linted. See #10. _But travis does, so I expected it would tell me._
